### PR TITLE
Reusable Components - Rental Location Map

### DIFF
--- a/app/components/map.hbs
+++ b/app/components/map.hbs
@@ -1,0 +1,9 @@
+<div class='map'>
+  <img
+    alt='Map image at coordinates {{@lat}},{{@lng}}'
+    ...attributes
+    src='https://api.mapbox.com/styles/v1/mapbox/streets-v11/static/{{@lng}},{{@lat}},{{@zoom}}/{{@width}}x{{@height}}@2x?access_token={{this.token}}'
+    width={{@width}}
+    height={{@height}}
+  />
+</div>

--- a/app/components/map.hbs
+++ b/app/components/map.hbs
@@ -2,7 +2,11 @@
   <img
     alt='Map image at coordinates {{@lat}},{{@lng}}'
     ...attributes
-    src='https://api.mapbox.com/styles/v1/mapbox/streets-v11/static/{{@lng}},{{@lat}},{{@zoom}}/{{@width}}x{{@height}}@2x?access_token={{this.token}}'
+    src='https://api.mapbox.com/styles/v1/mapbox/streets-v11/static/{{@lng}},{{@lat}},{{if
+      @zoom
+      @zoom
+      8.79
+    }}/{{@width}}x{{@height}}@2x?access_token={{this.token}}'
     width={{@width}}
     height={{@height}}
   />

--- a/app/components/map.hbs
+++ b/app/components/map.hbs
@@ -1,13 +1,13 @@
 <div class='map'>
   <img
-    alt='Map image at coordinates {{@lat}},{{@lng}}'
+    alt='Map image at coordinates {{if @lat @lat this.lat}},{{if
+      @lng
+      @lng
+      this.lng
+    }}'
+    width={{if @width @width this.width}}
+    height={{if @height @height this.height}}
     ...attributes
-    src='https://api.mapbox.com/styles/v1/mapbox/streets-v11/static/{{@lng}},{{@lat}},{{if
-      @zoom
-      @zoom
-      8.79
-    }}/{{@width}}x{{@height}}@2x?access_token={{this.token}}'
-    width={{@width}}
-    height={{@height}}
+    src={{this.src}}
   />
 </div>

--- a/app/components/map.js
+++ b/app/components/map.js
@@ -1,0 +1,15 @@
+import Component from '@glimmer/component';
+import ENV from 'ember-advanced-tutorial/config/environment';
+
+/*
+  The -gc flag stands for Glimmer component, but you may also remember it as "generate class":
+  ember -gc map --with-component-class
+*/
+
+export default class MapComponent extends Component {
+  get token() {
+    // It's important to URL-encode the token, just in case it contains any special characters that are not URL-safe
+    // https://javascript.info/url#encoding-strings
+    return encodeURIComponent(ENV.MAPBOX_ACCESS_TOKEN);
+  }
+}

--- a/app/components/map.js
+++ b/app/components/map.js
@@ -34,13 +34,6 @@ export default class MapComponent extends Component {
       zoom: zoomArg,
     } = this.args;
 
-    console.log({
-      widthArg,
-      width: this.width,
-      heightArg,
-      height: this.height,
-    });
-
     const coordinates = `${lngArg ?? this.lng},${latArg ?? this.lat},${
       zoomArg ?? this.zoom
     }`;

--- a/app/components/map.js
+++ b/app/components/map.js
@@ -6,10 +6,47 @@ import ENV from 'ember-advanced-tutorial/config/environment';
   ember -gc map --with-component-class
 */
 
+const MAPBOX_API = 'https://api.mapbox.com/styles/v1/mapbox/streets-v11/static';
+const defaultCoordinates = {
+  latitude: 37.7749,
+  longitude: -122.4194,
+};
+
 export default class MapComponent extends Component {
+  lng = defaultCoordinates.longitude;
+  lat = defaultCoordinates.latitude;
+  width = 150;
+  height = 150;
+  zoom = 8.79;
+
   get token() {
     // It's important to URL-encode the token, just in case it contains any special characters that are not URL-safe
     // https://javascript.info/url#encoding-strings
     return encodeURIComponent(ENV.MAPBOX_ACCESS_TOKEN);
+  }
+
+  get src() {
+    const {
+      lng: lngArg,
+      lat: latArg,
+      width: widthArg,
+      height: heightArg,
+      zoom: zoomArg,
+    } = this.args;
+
+    console.log({
+      widthArg,
+      width: this.width,
+      heightArg,
+      height: this.height,
+    });
+
+    const coordinates = `${lngArg ?? this.lng},${latArg ?? this.lat},${
+      zoomArg ?? this.zoom
+    }`;
+    const dimensions = `${widthArg ?? this.width}x${heightArg ?? this.height}`;
+    const accessToken = `access_token=${this.token}`;
+
+    return `${MAPBOX_API}/${coordinates}/${dimensions}@2x?${accessToken}`;
   }
 }

--- a/app/components/rental.hbs
+++ b/app/components/rental.hbs
@@ -22,4 +22,11 @@
       15
     </div>
   </div>
+  <Map
+    @lat='37.7749'
+    @lng='-122.4149'
+    @width='150'
+    @height='150'
+    alt='A map of Grand Old Mansion'
+  />
 </article>

--- a/app/components/rental.hbs
+++ b/app/components/rental.hbs
@@ -22,11 +22,5 @@
       15
     </div>
   </div>
-  <Map
-    @lat='37.7749'
-    @lng='-122.4149'
-    @width='150'
-    @height='150'
-    alt='A map of Grand Old Mansion'
-  />
+  <Map alt='A map of Grand Old Mansion' />
 </article>

--- a/config/environment.js
+++ b/config/environment.js
@@ -43,5 +43,11 @@ module.exports = function (environment) {
     // here you can enable a production-specific feature
   }
 
+  // helpful tip:
+  // the term running ember server, vscode, and ember server itself
+  // must be restarted after ensuring your env export is available
+  // or it will be undefined
+  ENV.MAPBOX_ACCESS_TOKEN = process.env.MAPBOX_ACCESS_TOKEN;
+
   return ENV;
 };

--- a/tests/integration/components/map-test.js
+++ b/tests/integration/components/map-test.js
@@ -45,6 +45,75 @@ module('Integration | Component | map', function (hooks) {
     );
   });
 
+  test('it updates the `src` attribute when the arguments change', async function (assert) {
+    /*
+      'this' refers to a special test context object, which we have access to inside 
+      the render helper. This provides a "bridge" for us to pass dynamic values 
+      (in the form of arguments into our invocation of the component) and allows us to 
+      update these values as needed from the test function.
+    */
+    this.setProperties({
+      lat: 37.7749,
+      lng: -122.4194,
+      zoom: 10,
+      width: 150,
+      height: 120,
+    });
+
+    /* this is also testing our "default" and "failover" logic in our JS class 
+       aka..."if decorator, then decorator, else this.value" */
+    await render(hbs`<Map
+        @lat={{this.lat}}
+        @lng={{this.lng}}
+        @zoom={{this.zoom}}
+        @width={{this.width}}
+        @height={{this.height}}
+      />`);
+
+    let img = find('.map img');
+
+    assert.ok(
+      img.src.includes('-122.4194,37.7749,10'),
+      'the src should include the lng,lat,zoom parameter'
+    );
+
+    assert.ok(
+      img.src.includes('150x120@2x'),
+      'the src should include the width,height and @2x parameter'
+    );
+
+    this.setProperties({
+      width: 300,
+      height: 200,
+      zoom: 12,
+    });
+
+    assert.ok(
+      img.src.includes('-122.4194,37.7749,12'),
+      'the src should include the lng,lat,zoom parameter'
+    );
+
+    assert.ok(
+      img.src.includes('300x200@2x'),
+      'the src should include the width,height and @2x parameter'
+    );
+
+    this.setProperties({
+      lat: 47.6062,
+      lng: -122.3321,
+    });
+
+    assert.ok(
+      img.src.includes('-122.3321,47.6062,12'),
+      'the src should include the lng,lat,zoom parameter'
+    );
+
+    assert.ok(
+      img.src.includes('300x200@2x'),
+      'the src should include the width,height and @2x parameter'
+    );
+  });
+
   // IMPORTANT: to read and understand this RE: order of HTML attributes... see implementation example in the HBS version of this file
   // https://guides.emberjs.com/release/tutorial/part-1/reusable-components/#toc_overriding-html-attributes-in-attributes
   test('the default alt attribute can be overridden', async function (assert) {

--- a/tests/integration/components/map-test.js
+++ b/tests/integration/components/map-test.js
@@ -70,8 +70,6 @@ module('Integration | Component | map', function (hooks) {
         @width="150"
         @height="120"
         src="/assets/images/teaching-tomster.png"
-        width="200"
-        height="300"
       />`);
 
     assert
@@ -89,5 +87,25 @@ module('Integration | Component | map', function (hooks) {
       .hasAttribute('src', /^https:\/\/api\.mapbox\.com\//)
       .hasAttribute('width', '150')
       .hasAttribute('height', '120');
+  });
+
+  test('the default values work in JS Class when no decorators are passed', async function (assert) {
+    await render(hbs`<Map />`); // Note how no decorators are being passed
+
+    assert
+      .dom('.map img')
+      .hasAttribute('width', '150') // default width
+      .hasAttribute('height', '150') // default height
+      .hasAttribute('alt', 'Map image at coordinates 37.7749,-122.4194');
+
+    let { src } = find('.map img');
+    assert.ok(
+      src.includes('-122.4194,37.7749,8.79'),
+      "the src should include the Class's default lng,lat,zoom parameter"
+    );
+    assert.ok(
+      src.includes('150x150@2x'),
+      "the src should include the Class's default width,height and @2x parameter"
+    );
   });
 });

--- a/tests/integration/components/map-test.js
+++ b/tests/integration/components/map-test.js
@@ -1,0 +1,83 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-advanced-tutorial/tests/helpers';
+import { find, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import ENV from 'ember-advanced-tutorial/config/environment';
+
+module('Integration | Component | map', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders a map image for the specified parameters', async function (assert) {
+    await render(hbs`<Map
+      @lat="37.7797"
+      @lng="-122.4184"
+      @zoom="10"
+      @width="150"
+      @height="120"
+    />`);
+
+    assert
+      .dom('.map img')
+      .exists()
+      .hasAttribute('alt', 'Map image at coordinates 37.7797,-122.4184')
+      .hasAttribute('src')
+      .hasAttribute('width', '150')
+      .hasAttribute('height', '120');
+
+    let { src } = find('.map img');
+    let token = encodeURIComponent(ENV.MAPBOX_ACCESS_TOKEN);
+
+    assert.ok(
+      src.startsWith('https://api.mapbox.com/'),
+      'the src starts with "https://api.mapbox.com/"'
+    );
+    assert.ok(
+      src.includes('-122.4184,37.7797,10'),
+      'the src should include the lng,lat,zoom parameter'
+    );
+    assert.ok(
+      src.includes('150x120@2x'),
+      'the src should include the width,height and @2x parameter'
+    );
+    assert.ok(
+      src.includes(`access_token=${token}`),
+      'the src should include the escaped access token'
+    );
+  });
+
+  // IMPORTANT: to read and understand this RE: order of HTML attributes... see implementation example in the HBS version of this file
+  // https://guides.emberjs.com/release/tutorial/part-1/reusable-components/#toc_overriding-html-attributes-in-attributes
+  test('the default alt attribute can be overridden', async function (assert) {
+    await render(hbs`<Map
+        @lat="37.7797"
+        @lng="-122.4184"
+        @zoom="10"
+        @width="150"
+        @height="120"
+        alt="A map of San Francisco"
+      />`);
+
+    assert.dom('.map img').hasAttribute('alt', 'A map of San Francisco');
+  });
+
+  // IMPORTANT: +1 to RE: order of HTML ATTRIBUTES...
+  // https://guides.emberjs.com/release/tutorial/part-1/reusable-components/#toc_overriding-html-attributes-in-attributes
+  test('the src, width and height attributes cannot be overridden', async function (assert) {
+    await render(hbs`<Map
+        @lat="37.7797"
+        @lng="-122.4184"
+        @zoom="10"
+        @width="150"
+        @height="120"
+        src="/assets/images/teaching-tomster.png"
+        width="200"
+        height="300"
+      />`);
+
+    assert
+      .dom('.map img')
+      .hasAttribute('src', /^https:\/\/api\.mapbox\.com\//)
+      .hasAttribute('width', '150')
+      .hasAttribute('height', '120');
+  });
+});

--- a/tests/integration/components/map-test.js
+++ b/tests/integration/components/map-test.js
@@ -76,6 +76,16 @@ module('Integration | Component | map', function (hooks) {
 
     assert
       .dom('.map img')
+      /* 
+        very nice doc for qunit dom -- contains hasAttribute and many others in here:
+        https://github.com/mainmatter/qunit-dom/blob/master/API.md                     
+       */
+      /* 
+        Note that the hasAttribute test helper from qunit-dom supports using regular expressions 
+        We used this feature to confirm that the src attribute starts with https://api.mapbox.com/, 
+        as opposed to requiring it to be an exact match against a string. This allows us to be reasonably 
+        confident that the code is working correctly, without being overly-detailed in our tests.
+      */
       .hasAttribute('src', /^https:\/\/api\.mapbox\.com\//)
       .hasAttribute('width', '150')
       .hasAttribute('height', '120');

--- a/tests/integration/components/map-test.js
+++ b/tests/integration/components/map-test.js
@@ -96,15 +96,15 @@ module('Integration | Component | map', function (hooks) {
       .dom('.map img')
       .hasAttribute('width', '150') // default width
       .hasAttribute('height', '150') // default height
-      .hasAttribute('alt', 'Map image at coordinates 37.7749,-122.4194');
+      .hasAttribute('alt', 'Map image at coordinates 37.7749,-122.4194'); // default alt (set in template, not Class JS)
 
     let { src } = find('.map img');
     assert.ok(
-      src.includes('-122.4194,37.7749,8.79'),
+      src.includes('-122.4194,37.7749,8.79'), // default coordinates
       "the src should include the Class's default lng,lat,zoom parameter"
     );
     assert.ok(
-      src.includes('150x150@2x'),
+      src.includes('150x150@2x'), // default height/width again, but now just inside src
       "the src should include the Class's default width,height and @2x parameter"
     );
   });

--- a/tests/integration/components/rental-test.js
+++ b/tests/integration/components/rental-test.js
@@ -20,5 +20,6 @@ module('Integration | Component | rental', function (hooks) {
     assert.dom('article .detail.bedrooms').includesText('Number of bedrooms:');
     assert.dom('article .detail.bedrooms').includesText('15');
     assert.dom('article .image').exists();
+    assert.dom('article .map').exists();
   });
 });


### PR DESCRIPTION
# Main

Associated challenge/task:
https://guides.emberjs.com/release/tutorial/part-1/reusable-components/

I used this link to debug while I was adding the optional decorators logic (very handy!):
https://docs.mapbox.com/playground/static/

Added a Rental Location map that can be modified to show us the map for a given rental location.

The git commits do a decent job of listing what all has been added.

# Additional Note

Like a few other places in this tutorial, I am deviating from it to challenge my understanding. I find it much easier to learn when I am immediately applying what I have learned. Purely following a blueprint does teach me some things, but application of it "seals the deal" in my brain. 

I did not explicitly call this out in other places in this repo when I have done this, so felt it was ideal to call it out at least here. I think this is a nice enhancement (having optional decorator values) and was a nice way test my understanding!

# Demo Content

### Before Changes

![Screen Shot 2022-11-06 at 3 33 44 PM](https://user-images.githubusercontent.com/23172276/200201553-6ff42f3d-272d-479a-a5f5-227b24db2844.png)

### After Changes

![Screen Shot 2022-11-06 at 3 33 05 PM](https://user-images.githubusercontent.com/23172276/200201566-ff583bc9-b077-4ce2-b511-28d60d77040c.png)